### PR TITLE
Landerlini4bianco95

### DIFF
--- a/charts/interlink-all-in-one/templates/bundle.yaml
+++ b/charts/interlink-all-in-one/templates/bundle.yaml
@@ -191,8 +191,11 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              cd /interlink/nats-plugin/current
-              python3 -m uvicorn natsplugin:app --reload --host 0.0.0.0 --log-level={{ .Values.pluginLogLevel | default "info" }} --port 8000
+              while true;
+              do
+                cd /interlink/nats-plugin/current
+                python3 -m uvicorn natsplugin:app --host 0.0.0.0 --log-level={{ .Values.pluginLogLevel | default "info" }} --port 8000
+              done
 
           env:
             - name: DEBUG

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,5 +19,6 @@ RUN pip install \
   "htcondor" \
   "podman" \
   "pytest" \
+  "aiohttp" \
   "redis"
 

--- a/docs/providers/condor.md
+++ b/docs/providers/condor.md
@@ -1,1 +1,179 @@
 # Condor provider
+
+Condor jobs are submitted through a Condor Compute Entrypoint authenticated through Javascript Web Tokens (JWT) 
+provided by an Indigo IAM Instance. 
+
+We report below recipes to configure the condor provider.
+
+## Kubernetes
+
+The reported configuration works for INFN-T1 site. Modifications might be needed (especially for paths) in other 
+sites. Then at some point we will have cvmfs.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: condor-sub-build-conf
+data:
+  interlink.conf: |
+    # Volumes and directories configuring access to executor-local data
+    [volumes]
+
+    ### Area in the executor filesystem to be used for temporary files
+    scratch_area = "/tmp"
+
+    ### Location to cache singularity images in the executor filesystem
+    apptainer_cachedir = "/tmp/cache/apptainer"
+
+    ### Location where to look for pre-built images
+    image_dir = "/opt/exp_software/opssw/budda"
+
+    ### Colon-separated list of directories to include in $PATH to look for executables
+    additional_directories_in_path = ["/opt/exp_software/opssw/mabarbet/bin"]
+
+
+
+    # Options configuring the behavior of apptainer runtime
+    [apptainer]
+
+    ### Enables --fakeroot in apptainer exec/run commands
+    fakeroot = false
+
+    ### Enables --containall flag in apptainer exec/run commands
+    containall = false
+
+    ### Defines whether the host enables users to mount fuse volumes or not
+    fuse_mode = "host-privileged"
+
+    ### Do not propagate umask to the container, set default 0022 umask
+    no_init = false
+
+    ### Do not bind home by default
+    no_home = true
+
+    ### Drop all privileges from root user in container
+    no_privs = true
+
+    ### Enable nVidia GPU support
+    nvidia_support = false
+
+    ### Clean the environment of the spawned container
+    cleanenv = true
+
+
+
+    # Proxy to download pre-build Docker Images instead of rebuilding at each execution
+    [shub_proxy]
+
+    ### shub proxy instance used to retrieve cached singularity images. Without protocol!
+    server = "<insert shub-proxy endpoint>"
+
+    ### Master token of the proxy used to request and generate client tokens
+    master_token = "<insert shub-proxy master token>"
+
+
+  interlink.sh: |
+    echo "Cloning the repo"
+    git clone --quiet --branch main https://github.com/landerlini/interlink-condorce-plugin plugin &> log
+    echo "Repo cloned"
+    cd plugin
+
+    mkdir -p /opt/interlink
+    echo "Starting authentication procedure"
+    python3 -u natsprovider/tests/_auth.py /opt/interlink/refresh_token
+    export REFRESH_TOKEN=$(cat /opt/interlink/refresh_token)
+
+    while true
+    do
+      git pull &>> log
+
+      python3 -um natsprovider condor \
+          --queue "infncnaf" \
+          --shutdown-subject "*" \
+          --non-interactive
+
+    done
+
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: condor-submitter
+  labels:
+    app: interlink
+    component: condor-submitter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: interlink
+      component: condor-submitter
+  template:
+    metadata:
+      labels:
+        app: interlink
+        component: condor-submitter
+    spec:
+      securityContext:
+        fsGroup: 101
+
+      containers:
+        - name: condorprovider
+          image: "landerlini/interlink-condorce-plugin:v0.1.2"
+          command: ["/bin/bash", "-u", "/etc/interlink/interlink.sh"]
+
+          env:
+            - name: DEBUG
+              value: "true"
+            - name: TOKEN_VALIDITY_SECONDS
+              value: "1200"
+            - name: _condor_CONDOR_HOST
+              value: "ce01t-htc.cr.cnaf.infn.it:9619"
+            - name: CONDOR_POOL
+              value: "ce01t-htc.cr.cnaf.infn.it:9619"
+            - name: _condor_SCHEDD_HOST
+              value: "ce01t-htc.cr.cnaf.infn.it"
+            - name: CONDOR_SCHEDULER_NAME
+              value: "ce01t-htc.cr.cnaf.infn.it"
+            - name: IAM_ISSUER
+              value: "https://iam-t1-computing.cloud.cnaf.infn.it"
+            - name: IAM_CLIENT_ID
+              value: <iam client id>
+            - name: IAM_CLIENT_SECRET
+              value: <iam client secret>
+            - name: NATS_SUBJECT
+              value: "interlink"
+            - name: NATS_SERVER
+              value: <nats server connector>
+            - name: NATS_TIMEOUT_SECONDS
+              value: "60"
+            - name: DEFAULT_ALLOCATABLE_CPU
+              value: "1"
+            - name: DEFAULT_ALLOCATABLE_MEMORY
+              value: "2Gi"
+            - name: DEFAULT_ALLOCATABLE_PODS
+              value: "10"
+            - name: DEFAULT_ALLOCATABLE_GPUS
+              value: "0"
+
+          volumeMounts:
+            - name: condorplugin-conf
+              mountPath: /etc/interlink
+              readOnly: true
+
+
+      volumes:
+        - name: condorplugin-conf
+          configMap:
+            name: condor-sub-build-conf
+            items:
+              - key: interlink.conf
+                path: build.conf
+              - key: interlink.sh
+                path: interlink.sh
+```
+
+

--- a/docs/providers/podman.md
+++ b/docs/providers/podman.md
@@ -1,1 +1,48 @@
 # Podman provider
+Podman provider is an option for taking control of Virtual Machines (or bare machines) through a remote Kubernetes
+installation.
+
+!!! warning
+
+    Note! At the moment running with podman requires root privileges. 
+
+
+To install Podman, please [refer to the official documentation](https://podman.io/docs/installation#installing-on-linux).
+
+The simplest option to install the submitter is using pip
+```yaml
+pip install git+https://github.com/landerlini/interlink-condorce-plugin.git
+```
+
+The following script should work
+```bash
+#!/bin/bash
+export PODMAN_BASE_URL=unix:///run/podman/podman.sock
+export GITREPO="git+https://github.com/landerlini/interlink-condorce-plugin.git@main"
+
+pip install --update --force-reinstall $GITREPO
+
+while true
+do
+        pip install --force-reinstall --no-deps $GITREPO
+
+        interlink podman \
+                --build-config /data/interlink/podman-recas.cfg \
+                --server wss://<your NATS server here> \
+                --pool podman \
+                --cpu 85 \
+                --memory 1Ti \
+                --pods 123 \
+                --gpus 28 \
+                --responders 1 \
+                &> /data/interlink/logs/plugin.log
+done;
+```
+
+For production environments, it is a good idea to replace `@main` with a tagged version of the repository.
+
+## A configuration sample
+This configuration has been used for Podman in a machine hosted at ReCaS Bari.
+```yaml
+--8<-- "configs/podman-recas.cfg"
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,3 +28,4 @@ nav:
 
 markdown_extensions:
   - admonition
+  - pymdownx.snippets

--- a/natsprovider/BaseNatsProvider.py
+++ b/natsprovider/BaseNatsProvider.py
@@ -71,6 +71,7 @@ class BaseNatsProvider:
 
     async def maybe_refresh_build_config(self):
         for _ in self.required_updates('build_config', 60):
+            self._build_config = self._build_config.reload()
             config_subject = '.'.join((self._nats_subject, 'config', self._nats_pool))
             async with self.nats_connection() as nc:
                 await nc.publish(

--- a/natsprovider/__main__.py
+++ b/natsprovider/__main__.py
@@ -32,9 +32,9 @@ class AllProviders:
         return KubernetesProvider(**kwargs)
 
     @staticmethod
-    def slurm(nats_server: str, nats_queue: str, build_config: BuildConfig, resources: Resources, interactive_mode: bool):
+    def slurm(**kwargs):
         from .slurmprovider.SlurmProvider import SlurmProvider
-        return SlurmProvider(nats_server, nats_queue, build_config, resources, interactive_mode)
+        return SlurmProvider(**kwargs)
 
 def _create_and_operate_provider(args: argparse.Namespace, build_config: BuildConfig, leader: bool = False):
     """

--- a/natsprovider/__main__.py
+++ b/natsprovider/__main__.py
@@ -4,11 +4,8 @@ import os
 import string
 import logging
 import asyncio
-from distutils.command.build import build
 from signal import SIGINT, SIGTERM
 from argparse import ArgumentParser
-
-from tomli import load as toml_load
 
 from . import configuration as cfg
 from .BaseNatsProvider import BaseNatsProvider
@@ -20,19 +17,19 @@ MISSING_BUILD_CONFIG_ERROR_CODE = 127
 
 class AllProviders:
     @staticmethod
-    def condor(nats_server: str, nats_queue: str, build_config: BuildConfig, resources: Resources, interactive_mode: bool):
+    def condor(**kwargs):
         from .condor.CondorProvider import CondorProvider
-        return CondorProvider(nats_server, nats_queue, build_config, resources, interactive_mode)
+        return CondorProvider(**kwargs)
 
     @staticmethod
-    def podman(nats_server: str, nats_queue: str, build_config: BuildConfig, resources: Resources, interactive_mode: bool):
+    def podman(**kwargs):
         from .podmanprovider.PodmanProvider import PodmanProvider
-        return PodmanProvider(nats_server, nats_queue, build_config, resources, interactive_mode)
+        return PodmanProvider(**kwargs)
 
     @staticmethod
-    def interlink(nats_server: str, nats_queue: str, build_config: BuildConfig, resources: Resources, interactive_mode: bool):
+    def interlink(**kwargs):
         from .kubernetesprovider.KubernetesProvider import KubernetesProvider
-        return KubernetesProvider(nats_server, nats_queue, build_config, resources, interactive_mode)
+        return KubernetesProvider(**kwargs)
 
     @staticmethod
     def slurm(nats_server: str, nats_queue: str, build_config: BuildConfig, resources: Resources, interactive_mode: bool):
@@ -45,9 +42,12 @@ def _create_and_operate_provider(args: argparse.Namespace, build_config: BuildCo
     """
     provider: BaseNatsProvider = getattr(AllProviders, args.provider)(
         nats_server=args.server,
-        nats_queue=args.queue,
+        nats_pool=args.pool,
         build_config=build_config,
         interactive_mode=not args.non_interactive,
+        shutdown_subject=args.shutdown_subject,
+        # The provider leader(s) is in charge of updating the interlink provider on pool build-config and resources
+        leader=leader,
         resources=Resources(
             cpu=args.cpu,
             memory=args.memory,
@@ -55,9 +55,6 @@ def _create_and_operate_provider(args: argparse.Namespace, build_config: BuildCo
             gpus=args.gpus,
         )
     )
-
-    # The provider leader(s) is in charge of updating the interlink provider on queue build-config and resources
-    provider.leader = leader
 
     loop = asyncio.get_event_loop()
     loop.add_signal_handler(SIGINT, provider.maybe_stop)
@@ -97,14 +94,14 @@ def main():
     )
 
     parser.add_argument(
-        "--queue", "-q",
-        default="default-queue",
-        help="NATS queue or ResourceFlavor defining the NATS subject",
+        "--pool", "-q",
+        default="default-pool",
+        help="NATS pool or ResourceFlavor defining the NATS subject",
     )
 
     parser.add_argument(
         "--shutdown-subject", "-k",
-        default=None,
+        default="*",
         help="NATS subject triggering a shutdown (and possibly a restart) of this service",
     )
 
@@ -180,22 +177,10 @@ def main():
     )
     logging.debug("Enabled debug mode.")
 
-    if any([letter not in string.ascii_lowercase + '-' for letter in args.queue]):
-        raise ValueError(f"Invalid queue `{args.queue}`: queue names can only include lower-case letters.")
+    if any([letter not in string.ascii_lowercase + '-' for letter in args.pool]):
+        raise ValueError(f"Invalid pool `{args.pool}`: pool names can only include lower-case letters.")
 
-    tolerate_missing_build_config = (args.build_config is None)
-    build_config_file = args.build_config if args.build_config is not None else '/etc/interlink/build.conf'
-
-    if not os.path.exists(build_config_file):
-        if tolerate_missing_build_config:
-            logging.warning(f"Build configuration file {build_config_file} does not exist. Using default configuration.")
-            build_config = BuildConfig()
-        else:
-            logging.critical(f"Build configuration file {build_config_file} does not exist.")
-            exit(MISSING_BUILD_CONFIG_ERROR_CODE)
-    else:
-        with open(build_config_file, 'rb') as input_file:
-            build_config = BuildConfig(**toml_load(input_file))
+    build_config = BuildConfig.from_file(args.build_config)
 
     additional_responders = []
     if args.responders > 1:

--- a/natsprovider/apptainer_cmd_builder/ApptainerCmdBuilder.py
+++ b/natsprovider/apptainer_cmd_builder/ApptainerCmdBuilder.py
@@ -75,8 +75,8 @@ class ApptainerCmdBuilder(BaseModel, extra='forbid'):
         for container in self.init_containers:
             ret += [
                 container.exec(),
-                "echo -n $? > %s" % (container.return_code_path + ".init"),
-                "cp %s %s" % (container.log_path, container.log_path + ".init"),
+                "echo -n $? > %s" % container.return_code_path,
+                "cp %s %s" % (container.log_path, container.log_path),
             ]
 
         return '\n'.join(ret)
@@ -104,8 +104,8 @@ class ApptainerCmdBuilder(BaseModel, extra='forbid'):
 
         ret += [
             "tar cvf $SANDBOX/logs " + ' '.join([
-                *[f"-C {c.workdir} {os.path.basename(c.log_path)}.init" for c in self.init_containers],
-                *[f"-C {c.workdir} {os.path.basename(c.return_code_path)}.init" for c in self.init_containers],
+                *[f"-C {c.workdir} {os.path.basename(c.log_path)}" for c in self.init_containers],
+                *[f"-C {c.workdir} {os.path.basename(c.return_code_path)}" for c in self.init_containers],
                 *[f"-C {c.workdir} {os.path.basename(c.log_path)}" for c in self.containers],
                 *[f"-C {c.workdir} {os.path.basename(c.return_code_path)}" for c in self.containers],
             ])

--- a/natsprovider/apptainer_cmd_builder/BuildConfig.py
+++ b/natsprovider/apptainer_cmd_builder/BuildConfig.py
@@ -1,8 +1,14 @@
 import os
+import logging
+import traceback
 from io import StringIO
 import json
-from typing import List, Literal
+from typing import List, Literal, Union, Optional
 from pydantic import BaseModel, Field
+
+from tomli import load as toml_load, TOMLDecodeError
+
+MISSING_BUILD_CONFIG_ERROR_CODE = 127
 
 
 class BuildConfig(BaseModel):
@@ -132,6 +138,12 @@ class BuildConfig(BaseModel):
         description=SingularityHubProxy.__doc__
     )
 
+    input_toml_filename: Optional[str] = Field(
+        default=None,
+        exclude=True,
+        description="Internal. Stores the filename from which the config was taken to enable reloading."
+    )
+
     def __str__(self):
         ret = StringIO()
         schema = self.model_json_schema()
@@ -195,3 +207,48 @@ class BuildConfig(BaseModel):
             cleanenv=self.apptainer.cleanenv,
             unsquash=self.apptainer.unsquash,
         )
+
+    @property
+    def logger(self):
+        return logging.getLogger(self.__class__.__name__)
+
+
+    @classmethod
+    def from_file(cls, filename: Union[str, None]):
+        """
+        Loads the build config from a TOML file.
+        """
+        logger = logging.getLogger(cls.__name__)
+        tolerate_missing_file = (filename is None)
+        build_config_file = filename if filename is not None else '/etc/interlink/build.conf'
+
+        if not os.path.exists(build_config_file):
+            if tolerate_missing_file:
+                logger.warning(
+                    f"Build configuration file {build_config_file} does not exist. Using default configuration."
+                    )
+                return cls()
+            else:
+                logger.critical(f"Build configuration file {build_config_file} does not exist.")
+                exit(MISSING_BUILD_CONFIG_ERROR_CODE)
+        else:
+            with open(build_config_file, 'rb') as input_file:
+                return cls(**toml_load(input_file), input_toml_filename=build_config_file)
+
+    def reload(self):
+        """
+        Reload a BuildConfig from file.
+
+        Usage:
+            build_config = build_config.reload()
+        """
+        if self.input_toml_filename is None:
+            self.logger.warning(f"Cannot reload BuildConfig for unknown input file.")
+            return self
+
+        try:
+            return BuildConfig.from_file(self.input_toml_filename)
+        except (IOError, FileNotFoundError, TOMLDecodeError) as e:
+            logging.error(f"Update of BuildConfig failed.\n" + traceback.format_exc())
+            return self
+

--- a/natsprovider/condor/CondorProvider.py
+++ b/natsprovider/condor/CondorProvider.py
@@ -9,22 +9,8 @@ from ..apptainer_cmd_builder import BuildConfig
 CondorConfiguration.initialize_htcondor()
 
 class CondorProvider(BaseNatsProvider):
-    def __init__(
-            self,
-            nats_server: str,
-            nats_pool: str,
-            build_config: BuildConfig,
-            resources: Resources,
-            interactive_mode: bool
-    ):
-        BaseNatsProvider.__init__(
-            self,
-            nats_server=nats_server,
-            nats_pool=nats_pool,
-            build_config=build_config,
-            resources=resources,
-            interactive_mode=interactive_mode,
-        )
+    def __init__(self, **kwargs):
+        BaseNatsProvider.__init__(self, **kwargs)
         self.condor = CondorConfiguration()
 
     async def create_pod(self, job_name: str, job_sh: str, pod: interlink.PodRequest) -> str:

--- a/natsprovider/kubernetesprovider/KubernetesProvider.py
+++ b/natsprovider/kubernetesprovider/KubernetesProvider.py
@@ -17,11 +17,8 @@ from . import configuration as cfg
 class KubernetesProvider(BaseNatsProvider):
     def __init__(
             self,
-            nats_server: str,
-            nats_pool: str,
             build_config: BuildConfig,
-            resources: Resources,
-            interactive_mode: bool,
+            **kwargs,
     ):
         self._volumes = copy(build_config.volumes)
         build_config.volumes.scratch_area = "/scratch"
@@ -37,11 +34,8 @@ class KubernetesProvider(BaseNatsProvider):
 
         BaseNatsProvider.__init__(
             self,
-            nats_server=nats_server,
-            nats_pool=nats_pool,
             build_config=build_config,
-            resources=resources,
-            interactive_mode=interactive_mode,
+            **kwargs,
         )
 
     async def close_connections_callback(self):

--- a/natsprovider/podmanprovider/PodmanProvider.py
+++ b/natsprovider/podmanprovider/PodmanProvider.py
@@ -21,11 +21,8 @@ from .volumes import BindVolume, TmpFS
 class PodmanProvider(BaseNatsProvider):
     def __init__(
             self,
-            nats_server: str,
-            nats_pool: str,
             build_config: BuildConfig,
-            resources: Resources,
-            interactive_mode: bool,
+            **kwargs,
     ):
         self._volumes = copy(build_config.volumes)
         build_config.volumes.scratch_area = "/scratch"
@@ -35,11 +32,8 @@ class PodmanProvider(BaseNatsProvider):
 
         BaseNatsProvider.__init__(
             self,
-            nats_server=nats_server,
-            nats_pool=nats_pool,
-            interactive_mode=interactive_mode,
             build_config=build_config,
-            resources=resources,
+            **kwargs
         )
         self._podman_base_url = cfg.PODMAN_BASE_URL
 

--- a/natsprovider/slurmprovider/SlurmProvider.py
+++ b/natsprovider/slurmprovider/SlurmProvider.py
@@ -19,11 +19,8 @@ from .volumes import BindVolume, TmpFS
 class SlurmProvider(BaseNatsProvider):
     def __init__(
             self,
-            nats_server: str,
-            nats_pool: str,
             build_config: BuildConfig,
-            resources: Resources,
-            interactive_mode: bool,
+            **kwargs
     ):
         self._volumes = copy(build_config.volumes)
         build_config.volumes.scratch_area = "/scratch"
@@ -31,14 +28,7 @@ class SlurmProvider(BaseNatsProvider):
         build_config.volumes.image_dir = "/images"
         self._sandbox = cfg.LOCAL_SANDBOX
 
-        BaseNatsProvider.__init__(
-            self,
-            nats_server=nats_server,
-            nats_pool=nats_pool,
-            interactive_mode=interactive_mode,
-            build_config=build_config,
-            resources=resources,
-        )
+        BaseNatsProvider.__init__(self, build_config=build_config, **kwargs)
 
         # log the build config
         self.logger.info(f"Build config: {build_config}")

--- a/natsprovider/tests/_auth.py
+++ b/natsprovider/tests/_auth.py
@@ -12,26 +12,29 @@ The script generate a .env file that must be passed to pytest to define the vari
 the user against the CNAF Tier-1 to the purpose of running the tests.
 """
 
+import json
 import requests
 import textwrap
 import time
 import os
+import sys
 
 IAM_ISSUER = os.environ.get("IAM_ISSUER")
 IAM_CLIENT_ID = os.environ.get("IAM_CLIENT_ID")
 IAM_CLIENT_SECRET = os.environ.get("IAM_CLIENT_SECRET")
 
-SCOPES = [
-        'openid',
-        'profile',
-        'offline_access',
-        'wlcg.groups',
-        'wlcg',
-        'compute.create',
-        'compute.modify',
-        'compute.read',
-        'compute.cancel',
-    ]
+default_scopes = [
+    'openid',
+    'profile',
+    'offline_access',
+    'wlcg.groups',
+    'wlcg',
+    'compute.create',
+    'compute.modify',
+    'compute.read',
+    'compute.cancel',
+]
+SCOPES = json.loads(os.environ.get("IAM_SCOPES", json.dumps(default_scopes)))
 
 response = requests.post(
     os.environ["IAM_ISSUER"] + '/devicecode',
@@ -70,6 +73,13 @@ while True:
     else:
         token_response.raise_for_status()
 
+
+if len(sys.argv) > 1:
+    print(f"Writing refresh token to {sys.argv[1]}")
+    with open(sys.argv[1], "w") as f:
+        print(refresh_token, file=f)
+else:
+    print(f"Warning. No output file was set. Creating secret.env file.")
 
 with open("secret.env", "w") as f:
     print(textwrap.dedent(f"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     "orjson",
     "kubernetes",
     "tomli",
-    "aiohttp"
+    "aiohttp",
+    "redis",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Modifications breaking compatibility:
 * The argument of the `interlink` script defining the name of the resource pool changed from `--queue` to `--pool` for consistency with the naming scheme adopted in code and (wannabe) documentation. 
 * The `__main__` script, used to launch the CLI of the resource provider, configures the `BaseNatsProvider` by passing arguments to the inherited versions of the provider. The constructor of the inherited providers has been modified to accept transparently any `kwargs` and pass it transparently to the underlying, common, `BaseNatsProvider` interface. Where relevant, `build_config` is retained and modified before passing it to the costructor of `BaseNatsProvider`.